### PR TITLE
Add support for ioctl VIDIOC_S_CTRL

### DIFF
--- a/lib/src/encoder.rs
+++ b/lib/src/encoder.rs
@@ -39,7 +39,7 @@ pub trait EncoderState {}
 
 pub struct Encoder<S: EncoderState> {
     // Make sure to keep the device alive as long as we are.
-    device: Arc<Device>,
+    pub device: Arc<Device>,
     state: S,
 }
 

--- a/lib/src/ioctl.rs
+++ b/lib/src/ioctl.rs
@@ -19,6 +19,7 @@ mod qbuf;
 mod querybuf;
 mod querycap;
 mod reqbufs;
+mod s_ctrl;
 mod streamon;
 mod subscribe_event;
 
@@ -34,6 +35,7 @@ pub use qbuf::*;
 pub use querybuf::*;
 pub use querycap::*;
 pub use reqbufs::*;
+pub use s_ctrl::*;
 pub use streamon::*;
 pub use subscribe_event::*;
 

--- a/lib/src/ioctl/s_ctrl.rs
+++ b/lib/src/ioctl/s_ctrl.rs
@@ -1,0 +1,79 @@
+use std::convert::From;
+use std::os::unix::io::AsRawFd;
+
+use nix::{self, errno::Errno, Error};
+use thiserror::Error;
+
+use crate::bindings;
+
+/// Implementors can receive the result from the `s_ctrl` ioctl.
+pub trait Ctrl: Sized {
+    fn from_v4l2_control(v4l2_control: bindings::v4l2_control) -> Self;
+}
+
+/// Information for a V4L2 control. Safe variant of `struct v4l2_control`.
+#[derive(Debug, Clone)]
+pub struct Control {
+    v4l2_control: bindings::v4l2_control,
+}
+
+impl Control {
+    pub fn id(&self) -> u32 {
+        self.v4l2_control.id
+    }
+
+    pub fn value(&self) -> i32 {
+        self.v4l2_control.value
+    }
+}
+
+impl Ctrl for Control {
+    fn from_v4l2_control(v4l2_control: bindings::v4l2_control) -> Self {
+        Self { v4l2_control }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SCtrlError {
+    #[error("Invalid v4l2_control ID")]
+    InvalidId,
+    #[error("The v4l2_control valueis out of bounds")]
+    ValueOutOfBounds,
+    #[error("Device currently busy")]
+    DeviceBusy,
+    #[error("Attempted to set a read only control")]
+    ReadOnly,
+    #[error("Unexpected ioctl error: {0}")]
+    IoctlError(nix::Error),
+}
+
+impl From<Error> for SCtrlError {
+    fn from(error: Error) -> Self {
+        match error {
+            Errno::EINVAL => Self::InvalidId,
+            Errno::ERANGE => Self::ValueOutOfBounds,
+            Errno::EBUSY => Self::DeviceBusy,
+            Errno::EACCES => Self::ReadOnly,
+            error => Self::IoctlError(error),
+        }
+    }
+}
+
+pub type SCtrlResult<T> = Result<T, SCtrlError>;
+
+#[doc(hidden)]
+mod ioctl {
+    use crate::bindings::v4l2_control;
+    nix::ioctl_readwrite!(vidioc_s_ctrl, b'V', 28, v4l2_control);
+}
+
+/// Safe wrapper around the `VIDIOC_S_CTRL` ioctl.
+pub fn s_ctrl<T: Ctrl + std::fmt::Debug, F: AsRawFd>(
+    fd: &mut F,
+    id: u32,
+    value: i32,
+) -> Result<T, SCtrlError> {
+    let mut ctrl = bindings::v4l2_control { id, value };
+    unsafe { ioctl::vidioc_s_ctrl(fd.as_raw_fd(), &mut ctrl)? };
+    Ok(T::from_v4l2_control(ctrl))
+}


### PR DESCRIPTION
Closes #12 

I've largely used the other files in the `ioctl` as a template for this, rather than fully understanding the inner workings of your library. Does this look reasonable for an implementation of the above ioctl function call?

Of note, and it should probably be in a separate pull request, but I've made `Encoder.device` public. The purpose of this is to act as an escape hatch when using the `Encoder` api to drop down to the lower level `ioctl`. I'm not experienced with `Arc<_>`, so I don't know if it's more appropriate to make a separate method that looks more like this pseudocode:

```rust
pub fn device(&self) -> Arc<Device> {
    Arc::clone(self.device)
}
```