### PR TITLE
Add ENUM_FRAMESIZES and {G|S}_INPUT IOCTL support.

### DIFF
--- a/lib/src/ioctl.rs
+++ b/lib/src/ioctl.rs
@@ -25,6 +25,7 @@ mod reqbufs;
 mod request;
 mod streamon;
 mod subscribe_event;
+mod framesizes;
 
 pub use decoder_cmd::*;
 pub use dqbuf::*;
@@ -45,6 +46,7 @@ pub use reqbufs::*;
 pub use request::*;
 pub use streamon::*;
 pub use subscribe_event::*;
+pub use framesizes::*;
 
 use std::fmt::Debug;
 

--- a/lib/src/ioctl/framesizes.rs
+++ b/lib/src/ioctl/framesizes.rs
@@ -1,0 +1,37 @@
+use std::os::unix::io::AsRawFd;
+use thiserror::Error;
+
+use crate::{bindings, PixelFormat};
+
+pub trait FrameSize {
+    fn from(input: bindings::v4l2_frmsizeenum) -> Self;
+}
+
+#[doc(hidden)]
+mod ioctl {
+    use crate::bindings::v4l2_frmsizeenum;
+    nix::ioctl_readwrite!(vidioc_enum_framesizes, b'V', 74, v4l2_frmsizeenum);
+}
+
+
+#[derive(Debug, Error)]
+pub enum FrameSizeError {
+    #[error("Unexpected ioctl error: {0}")]
+    IoctlError(nix::Error),
+}
+
+pub fn enum_frame_sizes<T: FrameSize>(fd: &impl AsRawFd, index: u32, pixel_format: PixelFormat) -> Result<T, FrameSizeError>{
+    let mut frame_size = bindings::v4l2_frmsizeenum {
+        index,
+        pixel_format: pixel_format.into(),
+        ..unsafe {std::mem::zeroed()}
+    };
+
+        match unsafe {
+            ioctl::vidioc_enum_framesizes(fd.as_raw_fd(), &mut frame_size)
+        } {
+            Ok(_) => Ok(T::from(frame_size)),
+            Err(e) =>  Err(FrameSizeError::IoctlError(e))
+        }
+
+}


### PR DESCRIPTION
Add ENUM_FRAMESIZES and {G|S}_INPUT IOCTL support. This helps with basic camera support through v4l2r.