### PR TITLE
lib: add v4l2_frmivalenum safe accessor to union

### DIFF
--- a/lib/src/ioctl/frameintervals.rs
+++ b/lib/src/ioctl/frameintervals.rs
@@ -13,6 +13,40 @@ impl FrameIntervals for bindings::v4l2_frmivalenum {
     }
 }
 
+/// A wrapper for the 'v4l2_frmivalenum' union member types
+#[derive(Debug)]
+pub enum FrmIvalTypes<'a> {
+    Discrete(&'a bindings::v4l2_fract),
+    StepWise(&'a bindings::v4l2_frmival_stepwise),
+}
+
+impl bindings::v4l2_frmivalenum {
+    /// Safely access the intervals member of the struct based on the
+    /// returned index.
+    pub fn intervals(&self) -> Option<FrmIvalTypes> {
+        match self.index {
+            // SAFETY: the member of the union that gets used by the driver
+            // is determined by the index
+            bindings::v4l2_frmivaltypes_V4L2_FRMIVAL_TYPE_DISCRETE => {
+                Some(FrmIvalTypes::Discrete(unsafe {
+                    &self.__bindgen_anon_1.discrete
+                }))
+            }
+
+            // SAFETY: the member of the union that gets used by the driver
+            // is determined by the index
+            bindings::v4l2_frmivaltypes_V4L2_FRMIVAL_TYPE_CONTINUOUS
+            | bindings::v4l2_frmivaltypes_V4L2_FRMIVAL_TYPE_STEPWISE => {
+                Some(FrmIvalTypes::StepWise(unsafe {
+                    &self.__bindgen_anon_1.stepwise
+                }))
+            }
+
+            _ => None,
+        }
+    }
+}
+
 #[doc(hidden)]
 mod ioctl {
     use crate::bindings::v4l2_frmivalenum;

--- a/lib/src/ioctl/framesizes.rs
+++ b/lib/src/ioctl/framesizes.rs
@@ -13,6 +13,40 @@ impl FrameSize for bindings::v4l2_frmsizeenum {
     }
 }
 
+/// A wrapper for the 'v4l2_frmsizeenum' union member types
+#[derive(Debug)]
+pub enum FrmSizeTypes<'a> {
+    Discrete(&'a bindings::v4l2_frmsize_discrete),
+    StepWise(&'a bindings::v4l2_frmsize_stepwise),
+}
+
+impl bindings::v4l2_frmsizeenum {
+    /// Safely access the size member of the struct based on the
+    /// returned index.
+    pub fn size(&self) -> Option<FrmSizeTypes> {
+        match self.index {
+            // SAFETY: the member of the union that gets used by the driver
+            // is determined by the index
+            bindings::v4l2_frmsizetypes_V4L2_FRMSIZE_TYPE_DISCRETE => {
+                Some(FrmSizeTypes::Discrete(unsafe {
+                    &self.__bindgen_anon_1.discrete
+                }))
+            }
+
+            // SAFETY: the member of the union that gets used by the driver
+            // is determined by the index
+            bindings::v4l2_frmsizetypes_V4L2_FRMSIZE_TYPE_CONTINUOUS
+            | bindings::v4l2_frmsizetypes_V4L2_FRMSIZE_TYPE_STEPWISE => {
+                Some(FrmSizeTypes::StepWise(unsafe {
+                    &self.__bindgen_anon_1.stepwise
+                }))
+            }
+
+            _ => None,
+        }
+    }
+}
+
 #[doc(hidden)]
 mod ioctl {
     use crate::bindings::v4l2_frmsizeenum;


### PR DESCRIPTION
Add an accessor for `v4l2_frmivalenum` anonymous
union members, avoiding having to write the union
name and safely returning the appropriate member of the union that is used.