### PR TITLE
ioctl: use the type field to determine FrmIvalTypes and FrmSizeTypes

### DIFF
--- a/lib/src/ioctl/frameintervals.rs
+++ b/lib/src/ioctl/frameintervals.rs
@@ -15,11 +15,11 @@ pub enum FrmIvalTypes<'a> {
 
 impl v4l2_frmivalenum {
     /// Safely access the intervals member of the struct based on the
-    /// returned index.
+    /// returned type.
     pub fn intervals(&self) -> Option<FrmIvalTypes> {
-        match self.index {
+        match self.type_ {
             // SAFETY: the member of the union that gets used by the driver
-            // is determined by the index
+            // is determined by the type
             bindings::v4l2_frmivaltypes_V4L2_FRMIVAL_TYPE_DISCRETE => {
                 Some(FrmIvalTypes::Discrete(unsafe {
                     &self.__bindgen_anon_1.discrete
@@ -27,7 +27,7 @@ impl v4l2_frmivalenum {
             }
 
             // SAFETY: the member of the union that gets used by the driver
-            // is determined by the index
+            // is determined by the type
             bindings::v4l2_frmivaltypes_V4L2_FRMIVAL_TYPE_CONTINUOUS
             | bindings::v4l2_frmivaltypes_V4L2_FRMIVAL_TYPE_STEPWISE => {
                 Some(FrmIvalTypes::StepWise(unsafe {

--- a/lib/src/ioctl/framesizes.rs
+++ b/lib/src/ioctl/framesizes.rs
@@ -15,11 +15,11 @@ pub enum FrmSizeTypes<'a> {
 
 impl v4l2_frmsizeenum {
     /// Safely access the size member of the struct based on the
-    /// returned index.
+    /// returned type.
     pub fn size(&self) -> Option<FrmSizeTypes> {
-        match self.index {
+        match self.type_ {
             // SAFETY: the member of the union that gets used by the driver
-            // is determined by the index
+            // is determined by the type
             bindings::v4l2_frmsizetypes_V4L2_FRMSIZE_TYPE_DISCRETE => {
                 Some(FrmSizeTypes::Discrete(unsafe {
                     &self.__bindgen_anon_1.discrete
@@ -27,7 +27,7 @@ impl v4l2_frmsizeenum {
             }
 
             // SAFETY: the member of the union that gets used by the driver
-            // is determined by the index
+            // is determined by the type
             bindings::v4l2_frmsizetypes_V4L2_FRMSIZE_TYPE_CONTINUOUS
             | bindings::v4l2_frmsizetypes_V4L2_FRMSIZE_TYPE_STEPWISE => {
                 Some(FrmSizeTypes::StepWise(unsafe {


### PR DESCRIPTION
The types should be determined by the type field instead of index according to:
https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-enum-framesizes.html https://www.kernel.org/doc/html/latest/userspace-api/media/v4l/vidioc-enum-frameintervals.html