### PR TITLE
Bump bindgen version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,16 +54,14 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -72,7 +70,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.61",
- "which",
 ]
 
 [[package]]
@@ -252,15 +249,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,18 +289,6 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -636,18 +612,6 @@ dependencies = [
  "nix",
  "thiserror",
  "v4l2r",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4.14"
 enumn = "0.1.6"
 
 [build-dependencies]
-bindgen = "0.69"
+bindgen = "0.70.1"
 
 # For example programs
 [dev-dependencies]

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -13,6 +13,9 @@ const DEFAULT_VIDEODEV2_H_PATH: &str = "/usr/include/linux";
 /// Wrapper file to use as input of bindgen.
 const WRAPPER_H: &str = "v4l2r_wrapper.h";
 
+// Fix for https://github.com/rust-lang/rust-bindgen/issues/753
+const FIX753_H: &str = "fix753.h";
+
 fn main() {
     let videodev2_h_path = env::var(V4L2R_VIDEODEV_ENV)
         .or_else(|e| {
@@ -28,6 +31,7 @@ fn main() {
 
     println!("cargo::rerun-if-env-changed={}", V4L2R_VIDEODEV_ENV);
     println!("cargo::rerun-if-changed={}", videodev2_h.display());
+    println!("cargo::rerun-if-changed={}", FIX753_H);
     println!("cargo::rerun-if-changed={}", WRAPPER_H);
 
     let clang_args = [


### PR DESCRIPTION
This bump was required as it was causing fix753 workaround to fail.