### PR TITLE
ioctl: Expose V4L2_BUF_FLAG_ERROR

### DIFF
--- a/lib/src/ioctl.rs
+++ b/lib/src/ioctl.rs
@@ -438,6 +438,10 @@ impl V4l2Buffer {
         self.flags().contains(BufferFlags::LAST)
     }
 
+    pub fn has_error(&self) -> bool {
+        self.flags().contains(BufferFlags::ERROR)
+    }
+
     pub fn timestamp(&self) -> bindings::timeval {
         self.buffer.timestamp
     }


### PR DESCRIPTION
Buffers can dequeue correctly, but have incorrect contents. This will be flagged by the driver by setting the V4L2_BUF_FLAG_ERROR.