### PR TITLE
Ensure license file is published with each crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members = ["lib", "ffi"]
 
 [workspace.package]
 readme = "README.md"
+license-file = "LICENSE"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["os"]
 keywords = ["v4l2", "video", "linux", "ffi"]
 license = "MIT"
 
+license-file.workspace = true
 readme.workspace = true
 
 [lib]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["os"]
 keywords = ["v4l2", "video", "linux"]
 license = "MIT"
 
+license-file.workspace = true
 readme.workspace = true
 
 [features]


### PR DESCRIPTION
As the license file is present at the root of the repository, it isn't part of any crate on crates.io, as those lie in subfolders. Ensure this file is published by telling cargo where to find it.