### PR TITLE
Add flag support for QBuffer

### DIFF
--- a/lib/src/ioctl.rs
+++ b/lib/src/ioctl.rs
@@ -302,6 +302,28 @@ bitflags! {
         const TSTAMP_SRC_SOE = bindings::V4L2_BUF_FLAG_TSTAMP_SRC_SOE;
         const REQUEST_FD = bindings::V4L2_BUF_FLAG_REQUEST_FD;
     }
+
+    /// Subset of [`BufferFlags`] that can be set by the user when queueing a buffer.
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct QBufferFlags: u32 {
+        const KEYFRAME = bindings::V4L2_BUF_FLAG_KEYFRAME;
+        const PFRAME = bindings::V4L2_BUF_FLAG_PFRAME;
+        const BFRAME = bindings::V4L2_BUF_FLAG_BFRAME;
+        const TIMECODE = bindings::V4L2_BUF_FLAG_TIMECODE;
+        const NO_CACHE_INVALIDATE = bindings::V4L2_BUF_FLAG_NO_CACHE_INVALIDATE;
+        const NO_CACHE_CLEAN = bindings::V4L2_BUF_FLAG_NO_CACHE_CLEAN;
+        const TIMESTAMP_MONOTONIC = bindings::V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
+        const TIMESTAMP_COPY = bindings::V4L2_BUF_FLAG_TIMESTAMP_COPY;
+        const TSTAMP_SRC_EOF = bindings::V4L2_BUF_FLAG_TSTAMP_SRC_EOF;
+        const TSTAMP_SRC_SOE = bindings::V4L2_BUF_FLAG_TSTAMP_SRC_SOE;
+    }
+
+}
+
+impl From<QBufferFlags> for BufferFlags {
+    fn from(value: QBufferFlags) -> Self {
+        Self::from_bits_retain(value.bits())
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, N)]

--- a/lib/src/ioctl.rs
+++ b/lib/src/ioctl.rs
@@ -293,8 +293,8 @@ bitflags! {
         const BFRAME = bindings::V4L2_BUF_FLAG_BFRAME;
         const TIMECODE = bindings::V4L2_BUF_FLAG_TIMECODE;
         const PREPARED = bindings::V4L2_BUF_FLAG_PREPARED;
-        const NO_CACHE_INVALIDATE = bindings::V4L2_BUF_FLAG_NO_CACHE_CLEAN;
-        const NO_CACHE_CLEAN = bindings::V4L2_BUF_FLAG_NO_CACHE_INVALIDATE;
+        const NO_CACHE_INVALIDATE = bindings::V4L2_BUF_FLAG_NO_CACHE_INVALIDATE;
+        const NO_CACHE_CLEAN = bindings::V4L2_BUF_FLAG_NO_CACHE_CLEAN;
         const LAST = bindings::V4L2_BUF_FLAG_LAST;
         const TIMESTAMP_MONOTONIC = bindings::V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
         const TIMESTAMP_COPY = bindings::V4L2_BUF_FLAG_TIMESTAMP_COPY;


### PR DESCRIPTION
Skipping cache flush/invalidation is an important optimization for non-coherent V4L2 MMAP buffers. In order to leverage this, clients need to be able to set the V4L2_BUF_FLAG_NO_CACHE_CLEAN and  V4L2_BUF_FLAG_NO_CACHE_INVALIDATE flags on v4l2_buffers before QBUF. This can't be done automatically on the driver side because the correctness of cache behavior technically depends on how the client uses these buffers. For example, usually we can set V4L2_BUF_FLAG_NO_CACHE_CLEAN on CAPTURE buffers for decoders, because this buffer is only written to by the decoder hardware, so flushing the CPU cache on every QBUF is expensive and unnecessary. However, if a client chooses to write to a CAPTURE buffer using the CPU for some reason, skipping the cache flush can cause a data race between the cache writeback and the decoder hardware.

This PR exposes the flag field on QBuffer to allow clients to modify v4l2_buffer flags at their discretion.